### PR TITLE
fixes #7: reduce cursor polling from 16ms to 100ms

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -125,7 +125,7 @@ const createWindow = () => {
     } else {
       win.setIgnoreMouseEvents(true);
     }
-  }, 16);
+  }, 100);
 
   win.on('moved', () => {
     const [x, y] = win.getPosition();


### PR DESCRIPTION
**What changed**
Reduced cursor hit-testing interval from 16ms to 100ms in createWindow.

**Why**
16ms (60fps) polling is unnecessary for detecting cursor hover over the overlay. 100ms is responsive enough and reduces CPU usage.

**How to test**
- [x] Move cursor over the overlay, verify it still becomes interactive
- [x] Move cursor away, verify click-through still works

**Checklist**
- [x] Builds clean
- [x] Tests pass
- [x] Tested manually