### PR TITLE
feat: spawn server as child process

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,6 +1,10 @@
 import axios from 'axios';
 import https from 'node:https';
 import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 let cert = null;
 let httpsAgent = null;
@@ -11,7 +15,7 @@ if (!process.parentPort) {
 }
 
 try {
-  cert = fs.readFileSync('riotgames.pem');
+  cert = fs.readFileSync(path.join(__dirname, 'riotgames.pem'));
   httpsAgent = new https.Agent({ ca: cert });
 } catch (error) {
   console.error(

--- a/server.js
+++ b/server.js
@@ -5,6 +5,11 @@ import fs from 'node:fs';
 let cert = null;
 let httpsAgent = null;
 
+if (!process.parentPort) {
+  console.error('server.js must be spawned via Electron utilityProcess.fork()');
+  process.exit(1);
+}
+
 try {
   cert = fs.readFileSync('riotgames.pem');
   httpsAgent = new https.Agent({ ca: cert });
@@ -17,32 +22,29 @@ try {
 
 async function getLiveGameData() {
   try {
-    const response = await axios.get(
+    const { data } = await axios.get(
       'https://127.0.0.1:2999/liveclientdata/allgamedata',
       { httpsAgent, timeout: 1000 },
     );
-    saveData(response.data);
-    return true;
+    return { success: true, data };
   } catch (error) {
-    if (fs.existsSync('current.json')) {
-      fs.unlinkSync('current.json');
-    }
-    console.log(error instanceof Error ? error.message : 'Unknown error');
-    return false;
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    };
   }
 }
 
-function saveData(newData) {
-  fs.writeFileSync('current.json.tmp', JSON.stringify(newData));
-  fs.renameSync('current.json.tmp', 'current.json');
-}
-
 async function startPolling() {
-  const success = await getLiveGameData();
+  const result = await getLiveGameData();
 
-  const nextDelay = success ? 1000 : 6000;
+  const nextDelay = result.success ? 1000 : 6000;
 
-  if (!success) console.log('Game not found, retrying in 6s...');
+  const msg = result.success
+    ? { type: 'DATA', payload: result.data }
+    : { type: 'FETCH_ERROR', reason: result.error };
+
+  process.parentPort.postMessage(msg);
 
   setTimeout(startPolling, nextDelay);
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,30 +1,19 @@
-import { app, BrowserWindow, globalShortcut, ipcMain, screen } from 'electron';
+import {
+  app,
+  BrowserWindow,
+  globalShortcut,
+  ipcMain,
+  screen,
+  utilityProcess,
+} from 'electron';
 import Store from 'electron-store';
-import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import config from '../../data/config.json' with { type: 'json' };
-import prompts from '../../data/prompts.json' with { type: 'json' };
-import {
-  type PromptCategory,
-  type Position,
-  type StateChangeEvent,
-} from '../types.js';
-import type { GameSnapshot } from '../riot.types.js';
-import {
-  deriveContext,
-  initialContextState,
-  type ContextState,
-} from './context.js';
+import type { Position } from '../types.js';
+import { handleServerMessage, togglePromptLoop } from './prompts.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, '..', '..');
-
-let timerId: NodeJS.Timeout;
-let timerRunning = true;
-
-let contextState: ContextState = { ...initialContextState };
-let lastCategory: PromptCategory | null = null;
 
 const store = new Store<Position>({
   defaults: {
@@ -32,63 +21,6 @@ const store = new Store<Position>({
     y: 0,
   },
 });
-
-function readCurrentSnapshot(): GameSnapshot | null {
-  try {
-    const raw = fs.readFileSync(path.join(rootDir, 'current.json'), 'utf-8');
-    return JSON.parse(raw) as GameSnapshot;
-  } catch {
-    return null;
-  }
-}
-
-function sendStateChange(win: BrowserWindow, event: StateChangeEvent) {
-  win.webContents.send('state-change', event);
-}
-
-function getContextPrompt(): string | null {
-  const snapshot = readCurrentSnapshot();
-  if (!snapshot) {
-    contextState = { ...initialContextState };
-    lastCategory = null;
-    return null;
-  }
-
-  const { result, newState } = deriveContext(snapshot, contextState);
-  contextState = newState;
-
-  if (!result) return null;
-
-  if (result.category === lastCategory) return null;
-
-  const pool = prompts[result.category];
-  if (!pool || pool.length === 0) return null;
-
-  lastCategory = result.category;
-  return pool[Math.floor(Math.random() * pool.length)] ?? null;
-}
-
-function handleSetPrompt(win: BrowserWindow) {
-  const timeout = Math.floor(
-    Math.random() * (config.idle_max_ms - config.idle_min_ms) +
-      config.idle_min_ms,
-  );
-
-  timerId = setTimeout(() => {
-    const prompt = getContextPrompt();
-
-    if (prompt) {
-      sendStateChange(win, { state: 'active', prompt });
-    }
-
-    timerId = setTimeout(() => {
-      if (prompt) {
-        sendStateChange(win, { state: 'cooldown' });
-      }
-      handleSetPrompt(win);
-    }, config.active_duration_ms);
-  }, timeout);
-}
 
 const createWindow = () => {
   const win = new BrowserWindow({
@@ -149,25 +81,24 @@ const createWindow = () => {
 
 app.whenReady().then(() => {
   const win = createWindow();
+  const server = utilityProcess.fork(path.join(rootDir, 'server.js'));
 
   ipcMain.on('set-position', (_event, pos: { dx: number; dy: number }) => {
     const [currentX, currentY] = win.getPosition() as [number, number];
     win.setPosition(currentX + pos.dx, currentY + pos.dy);
   });
 
-  // TODO: captures `win` - will break if window is recreated
-  globalShortcut.register('CommandOrControl+Shift+M', () => {
-    if (timerRunning) {
-      clearTimeout(timerId);
-      sendStateChange(win, { state: 'idle' });
-      timerRunning = false;
-    } else {
-      handleSetPrompt(win);
-      timerRunning = true;
-    }
+  server.on('message', (response) => {
+    handleServerMessage(response, win);
   });
 
-  handleSetPrompt(win);
+  globalShortcut.register('CommandOrControl+Shift+M', () => {
+    togglePromptLoop(win);
+  });
+
+  app.on('before-quit', () => {
+    server.kill();
+  });
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow();

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -10,7 +10,11 @@ import Store from 'electron-store';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { Position } from '../types.js';
-import { handleServerMessage, togglePromptLoop } from './prompts.js';
+import {
+  handleServerMessage,
+  stopPromptLoop,
+  togglePromptLoop,
+} from './prompts.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, '..', '..');
@@ -80,7 +84,7 @@ const createWindow = () => {
 };
 
 app.whenReady().then(() => {
-  const win = createWindow();
+  let win = createWindow();
   const server = utilityProcess.fork(path.join(rootDir, 'server.js'));
 
   ipcMain.on('set-position', (_event, pos: { dx: number; dy: number }) => {
@@ -92,6 +96,10 @@ app.whenReady().then(() => {
     handleServerMessage(response, win);
   });
 
+  server.on('exit', () => {
+    stopPromptLoop();
+  });
+
   globalShortcut.register('CommandOrControl+Shift+M', () => {
     togglePromptLoop(win);
   });
@@ -101,7 +109,9 @@ app.whenReady().then(() => {
   });
 
   app.on('activate', () => {
-    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+    if (BrowserWindow.getAllWindows().length === 0) {
+      win = createWindow();
+    }
   });
 });
 

--- a/src/main/prompts.ts
+++ b/src/main/prompts.ts
@@ -27,10 +27,7 @@ export function handleServerMessage(
   win: BrowserWindow,
 ) {
   if (response.type === 'FETCH_ERROR') {
-    engineStatus = 'WAITING_FOR_GAME';
-    latestSnapshot = null;
-    contextState = { ...initialContextState };
-    lastCategory = null;
+    stopPromptLoop();
     return;
   }
 
@@ -92,6 +89,15 @@ export function startPromptLoop(win: BrowserWindow) {
   if (timerRunning) return;
   timerRunning = true;
   scheduleNext(win);
+}
+
+export function stopPromptLoop() {
+  clearTimeout(timerId);
+  timerRunning = false;
+  engineStatus = 'WAITING_FOR_GAME';
+  latestSnapshot = null;
+  contextState = { ...initialContextState };
+  lastCategory = null;
 }
 
 export function togglePromptLoop(win: BrowserWindow) {

--- a/src/main/prompts.ts
+++ b/src/main/prompts.ts
@@ -1,0 +1,105 @@
+import type { BrowserWindow } from 'electron';
+import type { GameSnapshot } from '../riot.types.js';
+import type { PromptCategory, StateChangeEvent } from '../types.js';
+import config from '../../data/config.json' with { type: 'json' };
+import prompts from '../../data/prompts.json' with { type: 'json' };
+import {
+  deriveContext,
+  initialContextState,
+  type ContextState,
+} from './context.js';
+
+let contextState: ContextState = { ...initialContextState };
+let lastCategory: PromptCategory | null = null;
+let timerId: NodeJS.Timeout;
+let timerRunning = false;
+let latestSnapshot: GameSnapshot | null = null;
+
+type EngineStatus = 'WAITING_FOR_GAME' | 'ACTIVE' | 'COOLDOWN';
+let engineStatus: EngineStatus = 'WAITING_FOR_GAME';
+
+type ServerMessage =
+  | { type: 'DATA'; payload: GameSnapshot }
+  | { type: 'FETCH_ERROR'; reason: string };
+
+export function handleServerMessage(
+  response: ServerMessage,
+  win: BrowserWindow,
+) {
+  if (response.type === 'FETCH_ERROR') {
+    engineStatus = 'WAITING_FOR_GAME';
+    latestSnapshot = null;
+    contextState = { ...initialContextState };
+    lastCategory = null;
+    return;
+  }
+
+  latestSnapshot = response.payload;
+
+  if (engineStatus === 'WAITING_FOR_GAME') {
+    engineStatus = 'ACTIVE';
+    startPromptLoop(win);
+  }
+}
+
+function pickPrompt(): string | null {
+  if (!latestSnapshot) {
+    contextState = { ...initialContextState };
+    lastCategory = null;
+    return null;
+  }
+
+  const { result, newState } = deriveContext(latestSnapshot, contextState);
+  contextState = newState;
+
+  if (!result) return null;
+  if (result.category === lastCategory) return null;
+
+  const pool = prompts[result.category];
+  if (!pool || pool.length === 0) return null;
+
+  lastCategory = result.category;
+  return pool[Math.floor(Math.random() * pool.length)] ?? null;
+}
+
+function sendStateChange(win: BrowserWindow, event: StateChangeEvent) {
+  win.webContents.send('state-change', event);
+}
+
+function scheduleNext(win: BrowserWindow) {
+  const timeout = Math.floor(
+    Math.random() * (config.idle_max_ms - config.idle_min_ms) +
+      config.idle_min_ms,
+  );
+
+  timerId = setTimeout(() => {
+    const prompt = pickPrompt();
+
+    if (prompt) {
+      sendStateChange(win, { state: 'active', prompt });
+    }
+
+    timerId = setTimeout(() => {
+      if (prompt) {
+        sendStateChange(win, { state: 'cooldown' });
+      }
+      scheduleNext(win);
+    }, config.active_duration_ms);
+  }, timeout);
+}
+
+export function startPromptLoop(win: BrowserWindow) {
+  if (timerRunning) return;
+  timerRunning = true;
+  scheduleNext(win);
+}
+
+export function togglePromptLoop(win: BrowserWindow) {
+  if (timerRunning) {
+    clearTimeout(timerId);
+    sendStateChange(win, { state: 'idle' });
+    timerRunning = false;
+  } else {
+    startPromptLoop(win);
+  }
+}


### PR DESCRIPTION
## Summary
- Extracts prompt logic (timer loop, state, snapshot handling) from `main.ts` into `prompts.ts`
- Server now runs as `utilityProcess` child, sends game data via IPC instead of writing `current.json`
- Typed `ServerMessage` union for IPC, double-start guard, server cleanup on quit

## Test plan
- [ ] `npm run build` passes
- [ ] `npm test` -- 56/56 passing
- [ ] Launch app with no game running -- server polls, overlay stays idle
- [ ] Launch with League running -- overlay starts showing prompts
- [ ] Ctrl+Shift+M toggles prompt loop on/off
- [ ] Quit app -- server process cleans up (no orphan)

Closes #1