### PR TITLE
feat: smart prompt engine v2

### DIFF
--- a/data/config.json
+++ b/data/config.json
@@ -1,4 +1,5 @@
 {
   "active_duration_ms": 5000,
-  "cooldown_ms": 10000
+  "cooldown_ms": 10000,
+  "output_mode": "both"
 }

--- a/data/prompts.json
+++ b/data/prompts.json
@@ -1,44 +1,41 @@
 {
   "map_awareness": [
     "Where is the enemy jungler right now?",
-    "Check minimap - who is missing?",
+    "Check minimap -- who is missing?",
     "Which lanes have priority?",
-    "Is anyone walking through river?",
     "How many enemies are visible on the map right now?",
     "Where would you gank if you were their jungler?",
-    "Enemy jungler started bot side - they're topside now. Watch out",
     "You haven't checked minimap in a while. Glance now",
-    "Which enemies have been off-map longest? Danger zone",
+    "Which enemies have been off-map longest?",
     "Can you predict the next gank? Where's the pressure?"
   ],
   "wave_management": [
-    "Is your wave pushing or pulling?",
+    "You're at {my_cs} CS -- expected around {expected_cs}. Focus on last hits",
+    "You're {my_cs} CS vs their {enemy_cs}. Close the gap",
     "Freeze, slow push, or shove? Pick one and commit",
     "Will this wave crash into tower before the next objective?",
     "Can you build a slow push for a dive or roam?",
-    "Is a cannon wave coming? Plan around it",
-    "Check sidelanes - are waves being caught?",
-    "Crash this wave before you recall. Don't waste the push",
-    "Can you set up a 3-wave slow push for the next objective?",
-    "Waves will arrive at tower every 30 seconds. Time your rotation"
+    "Check sidelanes -- are waves being caught?",
+    "Crash this wave before you recall",
+    "Can you set up a 3-wave slow push for the next objective?"
   ],
   "trading": [
+    "You just finished {item}. Look for a trade",
+    "{enemy} just completed {item}. Respect their spike",
+    "You hit level {level} -- you have the advantage. Trade now",
     "What cooldowns does your opponent have up?",
     "Do you have a level or item advantage right now?",
     "Where are the enemy minions? Don't trade in their wave",
     "Can you punish them for last hitting?",
-    "What's your win condition in this lane?",
-    "Are your summoner spells up? Are theirs?",
-    "Level 2 spike: first wave + 3 melee. Be ready"
+    "Are your summoner spells up? Are theirs?"
   ],
   "objectives": [
-    "Dragon spawns in 60 seconds. Push waves and set up vision NOW",
-    "Baron is coming up. Ping your team and start positioning",
+    "Dragon in {time_until}s. Push waves and set up vision NOW",
+    "Baron in {time_until}s. Ping your team and start positioning",
     "Are you going to contest this objective or trade across the map?",
     "Does the enemy have smite advantage?",
     "Rift Herald is up. Can your jungler take it?",
     "What's the dragon soul state? How many does each team have?",
-    "Is elder dragon coming? This decides the game",
     "Don't start baron without pushed waves. Check sidelanes first",
     "Can you take a tower instead of contesting this objective?"
   ],
@@ -48,42 +45,42 @@
     "Tab: check enemy summoner spell timers",
     "Tab: who is the biggest threat right now?",
     "Tab: does anyone have stopwatch or zhonyas?",
-    "Tab: compare CS numbers - are you ahead or behind?",
+    "Tab: compare CS numbers -- are you ahead or behind?",
     "Tab: who on their team is behind? Punish them",
     "Tab: check death timers. Can you force something?"
   ],
   "macro": [
+    "{dead_enemy} is dead for {respawn_timer}s. Push or take an objective",
+    "{dead_count} enemies are dead. What can you take right now?",
+    "You're {kills}/{deaths} -- press your lead. Force fights on your terms",
+    "You just won the teamfight ({our_kills} for {total_kills}). Take an objective NOW",
+    "Teamfight lost. Regroup, don't trickle in",
+    "You killed {victim}. What do you take? Tower? Dragon? Vision?",
     "What is your team's win condition this game?",
     "Should you be grouping or splitting right now?",
     "Which side of the map should you be playing around?",
-    "Can you take a tower if you push this wave?",
-    "Is this fight worth taking or should you give and take elsewhere?",
-    "Is the enemy comp better at teamfighting or picking? Play accordingly",
-    "Are you playing to your champion's strengths or the enemy's?",
-    "You just got a kill. What do you take? Tower? Dragon? Vision?",
-    "Don't fight without a reason. What do you gain if you win this?",
-    "Play towards your power spike. When do you hit your strongest point?"
+    "Don't fight without a reason. What do you gain if you win this?"
   ],
   "vision": [
     "Do you have vision on the objective? Place wards 60 seconds early",
     "Your ward is about to expire. Re-ward before it goes dark",
     "Sweep before your team walks into that brush",
     "Control ward the objective pit. Deny their vision",
-    "River is dark. Respect the fog - don't facecheck",
+    "River is dark. Respect the fog -- don't facecheck",
     "Where are their wards? Think about what they can see"
   ],
   "reset_timing": [
-    "You have enough gold for your next item. Crash and recall",
+    "You have {gold}g. That's enough for your next component -- crash and recall",
+    "You're sitting on {gold}g! Stop fighting and go spend it",
+    "You're at {hp_percent}% HP. Back off and reset before you give a free kill",
     "Objective spawns soon. Reset now so you're full HP",
-    "Don't overstay. You're low with no sums - back off and reset",
-    "Can you cheater recall? Crash wave 3 and back for free",
-    "You just won a fight. Don't greed - recall and spend your gold",
-    "Wave is pushing to you. Stay and catch it, then base"
+    "Don't overstay. You're low with no sums -- back off and reset",
+    "You just won a fight. Don't greed -- recall and spend your gold"
   ],
   "mental": [
     "Take a breath. Reset your focus",
     "Stop thinking about the last death. What's the play NOW?",
-    "Are you tilted? If yes, play safe for 2 minutes",
+    "You're 0/{deaths} -- play safe, farm under tower, scale. You'll be useful later",
     "Focus on what you can control, not your teammates",
     "One good play can flip this game. Stay sharp",
     "You died. That's fine. What went wrong and what's next?",

--- a/src/main/context.test.ts
+++ b/src/main/context.test.ts
@@ -6,6 +6,48 @@ import {
 } from './context.js';
 import type { GameSnapshot, Player } from '../riot.types.js';
 
+const defaultScores: Player['scores'] = {
+  assists: 0,
+  creepScore: 45,
+  deaths: 0,
+  kills: 0,
+  wardScore: 0,
+};
+
+const defaultRunes: Player['runes'] = {
+  keystone: {
+    displayName: 'Conqueror',
+    id: 8010,
+    rawDescription: '',
+    rawDisplayName: '',
+  },
+  primaryRuneTree: {
+    displayName: 'Precision',
+    id: 8000,
+    rawDescription: '',
+    rawDisplayName: '',
+  },
+  secondaryRuneTree: {
+    displayName: 'Resolve',
+    id: 8400,
+    rawDescription: '',
+    rawDisplayName: '',
+  },
+};
+
+const defaultSpells: Player['summonerSpells'] = {
+  summonerSpellOne: {
+    displayName: 'Flash',
+    rawDescription: '',
+    rawDisplayName: '',
+  },
+  summonerSpellTwo: {
+    displayName: 'Ignite',
+    rawDescription: '',
+    rawDisplayName: '',
+  },
+};
+
 // Base snapshot: 5 min in, normal game state, no events, no triggers
 function makeSnapshot(
   overrides: {
@@ -21,29 +63,152 @@ function makeSnapshot(
   const gameTime = overrides.gameTime ?? 300;
   return {
     activePlayer: {
+      abilities: {
+        Passive: {
+          displayName: 'Passive',
+          id: 'P',
+          rawDescription: '',
+          rawDisplayName: '',
+        },
+        Q: {
+          abilityLevel: 1,
+          displayName: 'Q',
+          id: 'Q',
+          rawDescription: '',
+          rawDisplayName: '',
+        },
+        W: {
+          abilityLevel: 0,
+          displayName: 'W',
+          id: 'W',
+          rawDescription: '',
+          rawDisplayName: '',
+        },
+        E: {
+          abilityLevel: 0,
+          displayName: 'E',
+          id: 'E',
+          rawDescription: '',
+          rawDisplayName: '',
+        },
+        R: {
+          abilityLevel: 0,
+          displayName: 'R',
+          id: 'R',
+          rawDescription: '',
+          rawDisplayName: '',
+        },
+      },
+      championStats: {
+        abilityHaste: 0,
+        abilityPower: 0,
+        armor: 30,
+        armorPenetrationFlat: 0,
+        armorPenetrationPercent: 1,
+        attackDamage: 60,
+        attackRange: 175,
+        attackSpeed: 0.65,
+        bonusArmorPenetrationPercent: 1,
+        bonusMagicPenetrationPercent: 1,
+        critChance: 0,
+        critDamage: 200,
+        currentHealth: 700,
+        healShieldPower: 0,
+        healthRegenRate: 1.8,
+        lifeSteal: 0,
+        magicLethality: 0,
+        magicPenetrationFlat: 0,
+        magicPenetrationPercent: 1,
+        magicResist: 32,
+        maxHealth: 700,
+        moveSpeed: 340,
+        omnivamp: 0,
+        physicalLethality: 0,
+        physicalVamp: 0,
+        resourceMax: 400,
+        resourceRegenRate: 1.6,
+        resourceType: 'MANA',
+        resourceValue: 400,
+        spellVamp: 0,
+        tenacity: 5,
+      },
       currentGold: overrides.gold ?? 500,
+      fullRunes: {
+        generalRunes: [],
+        keystone: {
+          displayName: 'Conqueror',
+          id: 8010,
+          rawDescription: '',
+          rawDisplayName: '',
+        },
+        primaryRuneTree: {
+          displayName: 'Precision',
+          id: 8000,
+          rawDescription: '',
+          rawDisplayName: '',
+        },
+        secondaryRuneTree: {
+          displayName: 'Resolve',
+          id: 8400,
+          rawDescription: '',
+          rawDisplayName: '',
+        },
+        statRunes: [],
+      },
       level: overrides.level ?? 1,
       riotId: 'Player#123',
       riotIdGameName: 'Player',
+      riotIdTagLine: '123',
+      summonerName: 'Player#123',
     },
     allPlayers: [
       {
-        riotId: 'Player#123',
-        position: 'MIDDLE',
-        team: 'ORDER',
+        championName: 'Sylas',
+        isBot: false,
         isDead: overrides.isDead ?? false,
-        scores: { creepScore: overrides.creepScore ?? 45 },
+        items: [],
+        level: overrides.level ?? 1,
+        position: 'MIDDLE',
+        respawnTimer: 0,
+        riotId: 'Player#123',
+        riotIdGameName: 'Player',
+        riotIdTagLine: '123',
+        runes: defaultRunes,
+        scores: {
+          ...defaultScores,
+          creepScore: overrides.creepScore ?? 45,
+        },
+        summonerSpells: defaultSpells,
+        team: 'ORDER',
       },
       {
-        riotId: 'Enemy#456',
-        position: 'MIDDLE',
-        team: 'CHAOS',
+        championName: 'Zed',
+        isBot: false,
         isDead: false,
-        scores: { creepScore: overrides.enemyCreepScore ?? 45 },
+        items: [],
+        level: overrides.level ?? 1,
+        position: 'MIDDLE',
+        respawnTimer: 0,
+        riotId: 'Enemy#456',
+        riotIdGameName: 'Enemy',
+        riotIdTagLine: '456',
+        runes: defaultRunes,
+        scores: {
+          ...defaultScores,
+          creepScore: overrides.enemyCreepScore ?? 45,
+        },
+        summonerSpells: defaultSpells,
+        team: 'CHAOS',
       },
     ],
     events: { Events: overrides.events ?? [] },
-    gameData: { gameTime },
+    gameData: {
+      gameMode: 'CLASSIC',
+      gameTime,
+      mapName: 'Map11',
+      mapNumber: 11,
+      mapTerrain: 'Default',
+    },
   };
 }
 

--- a/src/main/context.ts
+++ b/src/main/context.ts
@@ -16,8 +16,8 @@ export type ContextState = {
   lastKnownLevel: number;
   lastDragonKillTime: number;
   lastBaronKillTime: number;
-  lastMyItemCount: number;
-  lastEnemyItemCount: number;
+  lastMyItemIds: number[];
+  lastEnemyItemIds: number[];
 };
 
 export const initialContextState: ContextState = {
@@ -27,8 +27,8 @@ export const initialContextState: ContextState = {
   lastKnownLevel: 1,
   lastDragonKillTime: 0,
   lastBaronKillTime: 0,
-  lastMyItemCount: 0,
-  lastEnemyItemCount: 0,
+  lastMyItemIds: [],
+  lastEnemyItemIds: [],
 };
 
 function processEvents(

--- a/src/main/context.ts
+++ b/src/main/context.ts
@@ -1,23 +1,12 @@
-import type { GameEvent, GameSnapshot, Player } from '../riot.types.js';
+import type { GameEvent, GameSnapshot } from '../riot.types.js';
 import type { PromptCategory } from '../types.js';
-import {
-  CS_THRESHOLD,
-  DRAGON_FIRST_SPAWN_S,
-  DRAGON_RESPAWN_S,
-  BARON_FIRST_SPAWN_S,
-  BARON_RESPAWN_S,
-  GOLD_RECALL_MAX,
-  GOLD_RECALL_MIN,
-  GOLD_SITTING,
-  OBJECTIVE_UPCOMING_WINDOW_S,
-  TAB_CHECK_INTERVAL_S,
-  TRADING_LEVEL_SPIKES,
-  VISION_CHECK_INTERVAL_S,
-} from '../constants.js';
+import { getGamePhase, getCategoryWeight } from './phases.js';
+import { ALL_DETECTORS, type DetectorResult } from './detectors.js';
 
 export type ContextResult = {
   category: PromptCategory;
   reason: string;
+  data: Record<string, string>;
 };
 
 export type ContextState = {
@@ -27,6 +16,8 @@ export type ContextState = {
   lastKnownLevel: number;
   lastDragonKillTime: number;
   lastBaronKillTime: number;
+  lastMyItemCount: number;
+  lastEnemyItemCount: number;
 };
 
 export const initialContextState: ContextState = {
@@ -36,6 +27,8 @@ export const initialContextState: ContextState = {
   lastKnownLevel: 1,
   lastDragonKillTime: 0,
   lastBaronKillTime: 0,
+  lastMyItemCount: 0,
+  lastEnemyItemCount: 0,
 };
 
 function processEvents(
@@ -63,139 +56,6 @@ function processEvents(
   return newEvents;
 }
 
-function checkDeath(me: Player | undefined): ContextResult | null {
-  return me?.isDead ? { category: 'mental', reason: 'player_dead' } : null;
-}
-
-function checkPlayerKill(
-  newEvents: GameEvent[],
-  killerName: string,
-): ContextResult | null {
-  const kill = newEvents.find(
-    (e) => e.EventName === 'ChampionKill' && e.KillerName === killerName,
-  );
-  return kill ? { category: 'macro', reason: 'player_kill' } : null;
-}
-
-const OBJECTIVE_EVENTS = new Set([
-  'DragonKill',
-  'BaronKill',
-  'RiftHeraldKill',
-  'TurretKilled',
-  'InhibKilled',
-]);
-
-function checkObjectiveTaken(newEvents: GameEvent[]): ContextResult | null {
-  const event = newEvents.find((e) => OBJECTIVE_EVENTS.has(e.EventName));
-  return event ? { category: 'objectives', reason: event.EventName } : null;
-}
-
-function isObjectiveUpcoming(
-  gameTime: number,
-  lastKillTime: number,
-  firstSpawnTime: number,
-  respawnDelay: number,
-): boolean {
-  const nextSpawn =
-    lastKillTime === 0 ? firstSpawnTime : lastKillTime + respawnDelay;
-  return (
-    gameTime >= nextSpawn - OBJECTIVE_UPCOMING_WINDOW_S &&
-    gameTime < nextSpawn - 10
-  );
-}
-
-function checkObjectiveUpcoming(
-  gameTime: number,
-  state: ContextState,
-): ContextResult | null {
-  if (
-    isObjectiveUpcoming(
-      gameTime,
-      state.lastBaronKillTime,
-      BARON_FIRST_SPAWN_S,
-      BARON_RESPAWN_S,
-    )
-  ) {
-    return { category: 'objectives', reason: 'baron_upcoming' };
-  }
-  if (
-    isObjectiveUpcoming(
-      gameTime,
-      state.lastDragonKillTime,
-      DRAGON_FIRST_SPAWN_S,
-      DRAGON_RESPAWN_S,
-    )
-  ) {
-    return { category: 'objectives', reason: 'dragon_upcoming' };
-  }
-  return null;
-}
-
-function checkCSBehind(
-  me: Player | undefined,
-  allPlayers: Player[],
-  gameTime: number,
-): ContextResult | null {
-  if (!me) return null;
-
-  const expectedCS = (gameTime / 60) * 10;
-  if (expectedCS <= 20) return null;
-
-  const enemyLaner = allPlayers.find(
-    (p) => p.position === me.position && p.team !== me.team,
-  );
-
-  if (
-    me.scores.creepScore < expectedCS * CS_THRESHOLD &&
-    (!enemyLaner || me.scores.creepScore < enemyLaner.scores.creepScore - 2)
-  ) {
-    return { category: 'wave_management', reason: 'cs_behind' };
-  }
-  return null;
-}
-
-function checkGold(gold: number): ContextResult | null {
-  if (gold >= GOLD_RECALL_MIN && gold <= GOLD_RECALL_MAX) {
-    return { category: 'reset_timing', reason: 'recall_window' };
-  }
-  if (gold >= GOLD_SITTING) {
-    return { category: 'reset_timing', reason: 'sitting_on_gold' };
-  }
-  return null;
-}
-
-function checkLevelSpike(
-  level: number,
-  lastKnownLevel: number,
-): ContextResult | null {
-  if (level > lastKnownLevel && TRADING_LEVEL_SPIKES.includes(level)) {
-    return { category: 'trading', reason: `level_${level}` };
-  }
-  return null;
-}
-
-function checkVision(
-  gameTime: number,
-  newState: ContextState,
-): ContextResult | null {
-  if (gameTime - newState.lastVisionCheckAt >= VISION_CHECK_INTERVAL_S) {
-    newState.lastVisionCheckAt = gameTime;
-    return { category: 'vision', reason: 'periodic' };
-  }
-  return null;
-}
-
-function checkTabCheck(
-  gameTime: number,
-  newState: ContextState,
-): ContextResult | null {
-  if (gameTime - newState.lastTabCheckAt >= TAB_CHECK_INTERVAL_S) {
-    newState.lastTabCheckAt = gameTime;
-    return { category: 'tab_check', reason: 'periodic' };
-  }
-  return null;
-}
-
 export function deriveContext(
   snapshot: GameSnapshot,
   state: ContextState,
@@ -205,23 +65,48 @@ export function deriveContext(
 
   const newState: ContextState = { ...state };
   const me = allPlayers.find((p) => p.riotId === activePlayer.riotId);
+  const enemyLaner = me
+    ? allPlayers.find((p) => p.position === me.position && p.team !== me.team)
+    : undefined;
 
   newState.lastKnownLevel = activePlayer.level;
 
   const newEvents = processEvents(events.Events, state, newState);
+  const phase = getGamePhase(gameTime);
 
-  const result = checkDeath(me) ??
-    checkPlayerKill(newEvents, activePlayer.riotIdGameName) ??
-    checkObjectiveTaken(newEvents) ??
-    checkObjectiveUpcoming(gameTime, state) ??
-    checkCSBehind(me, allPlayers, gameTime) ??
-    checkGold(activePlayer.currentGold) ??
-    checkLevelSpike(activePlayer.level, state.lastKnownLevel) ??
-    checkVision(gameTime, newState) ??
-    checkTabCheck(gameTime, newState) ?? {
-      category: 'map_awareness' as PromptCategory,
-      reason: 'fallback',
+  const input = { snapshot, me, enemyLaner, newEvents, state, newState };
+
+  const results: DetectorResult[] = [];
+  for (const detector of ALL_DETECTORS) {
+    const result = detector(input);
+    if (result) {
+      const weight = getCategoryWeight(phase, result.category);
+      if (weight > 0) {
+        results.push({ ...result, priority: result.priority * weight });
+      }
+    }
+  }
+
+  if (results.length === 0) {
+    return {
+      result: {
+        category: 'map_awareness' as PromptCategory,
+        reason: 'fallback',
+        data: {},
+      },
+      newState,
     };
+  }
 
-  return { result, newState };
+  results.sort((a, b) => b.priority - a.priority);
+  const best = results[0]!;
+
+  return {
+    result: {
+      category: best.category,
+      reason: best.reason,
+      data: best.data,
+    },
+    newState,
+  };
 }

--- a/src/main/detectors.ts
+++ b/src/main/detectors.ts
@@ -1,0 +1,398 @@
+import type {
+  ActivePlayer,
+  GameEvent,
+  GameSnapshot,
+  Player,
+} from '../riot.types.js';
+import type { PromptCategory } from '../types.js';
+import type { ContextState } from './context.js';
+import {
+  CS_THRESHOLD,
+  DRAGON_FIRST_SPAWN_S,
+  DRAGON_RESPAWN_S,
+  BARON_FIRST_SPAWN_S,
+  BARON_RESPAWN_S,
+  GOLD_RECALL_MAX,
+  GOLD_RECALL_MIN,
+  GOLD_SITTING,
+  OBJECTIVE_UPCOMING_WINDOW_S,
+  TAB_CHECK_INTERVAL_S,
+  TRADING_LEVEL_SPIKES,
+  VISION_CHECK_INTERVAL_S,
+} from '../constants.js';
+
+export type DetectorResult = {
+  category: PromptCategory;
+  reason: string;
+  priority: number;
+  data: Record<string, string>;
+};
+
+type DetectorInput = {
+  snapshot: GameSnapshot;
+  me: Player | undefined;
+  enemyLaner: Player | undefined;
+  newEvents: GameEvent[];
+  state: ContextState;
+  newState: ContextState;
+};
+
+// --- Reactive detectors (event-driven, high priority) ---
+
+export function detectDeath(input: DetectorInput): DetectorResult | null {
+  if (!input.me?.isDead) return null;
+  return {
+    category: 'mental',
+    reason: 'player_dead',
+    priority: 95,
+    data: {},
+  };
+}
+
+export function detectPlayerKill(input: DetectorInput): DetectorResult | null {
+  const { newEvents, snapshot } = input;
+  const kill = newEvents.find(
+    (e) =>
+      e.EventName === 'ChampionKill' &&
+      e.KillerName === snapshot.activePlayer.riotIdGameName,
+  );
+  if (!kill) return null;
+  return {
+    category: 'macro',
+    reason: 'player_kill',
+    priority: 85,
+    data: { victim: kill.VictimName ?? 'unknown' },
+  };
+}
+
+const OBJECTIVE_EVENTS = new Set([
+  'DragonKill',
+  'BaronKill',
+  'RiftHeraldKill',
+  'TurretKilled',
+  'InhibKilled',
+]);
+
+export function detectObjectiveTaken(
+  input: DetectorInput,
+): DetectorResult | null {
+  const event = input.newEvents.find((e) => OBJECTIVE_EVENTS.has(e.EventName));
+  if (!event) return null;
+  return {
+    category: 'objectives',
+    reason: event.EventName,
+    priority: 80,
+    data: { objective: event.EventName },
+  };
+}
+
+export function detectTeamfight(input: DetectorInput): DetectorResult | null {
+  const { newEvents, snapshot } = input;
+  const gameTime = snapshot.gameData.gameTime;
+  const recentKills = newEvents.filter(
+    (e) => e.EventName === 'ChampionKill' && gameTime - e.EventTime < 10,
+  );
+  if (recentKills.length < 3) return null;
+
+  const myTeamKills = recentKills.filter((e) => {
+    const killer = snapshot.allPlayers.find(
+      (p) => p.riotIdGameName === e.KillerName,
+    );
+    return killer && killer.team === (input.me?.team ?? 'ORDER');
+  }).length;
+
+  const won = myTeamKills > recentKills.length - myTeamKills;
+  return {
+    category: 'macro',
+    reason: won ? 'teamfight_won' : 'teamfight_lost',
+    priority: 90,
+    data: {
+      total_kills: String(recentKills.length),
+      our_kills: String(myTeamKills),
+    },
+  };
+}
+
+// --- Proactive detectors (state-based, medium priority) ---
+
+export function detectHpCritical(input: DetectorInput): DetectorResult | null {
+  const { championStats } = input.snapshot.activePlayer;
+  if (championStats.maxHealth === 0) return null;
+  const hpPercent = championStats.currentHealth / championStats.maxHealth;
+  if (hpPercent >= 0.3) return null;
+  if (input.me?.isDead) return null;
+  return {
+    category: 'reset_timing',
+    reason: 'hp_critical',
+    priority: 75,
+    data: { hp_percent: String(Math.round(hpPercent * 100)) },
+  };
+}
+
+export function detectEnemyDeathWindow(
+  input: DetectorInput,
+): DetectorResult | null {
+  const { snapshot, me } = input;
+  if (!me) return null;
+
+  const deadEnemies = snapshot.allPlayers.filter(
+    (p) => p.team !== me.team && p.isDead && p.respawnTimer > 5,
+  );
+  if (deadEnemies.length === 0) return null;
+
+  const longestDead = deadEnemies.reduce(
+    (best, p) => (p.respawnTimer > best.respawnTimer ? p : best),
+    deadEnemies[0]!,
+  );
+
+  return {
+    category: 'macro',
+    reason: 'enemy_dead',
+    priority: 70,
+    data: {
+      dead_enemy: longestDead.championName,
+      respawn_timer: String(Math.round(longestDead.respawnTimer)),
+      dead_count: String(deadEnemies.length),
+    },
+  };
+}
+
+export function detectItemCompleted(
+  input: DetectorInput,
+): DetectorResult | null {
+  const { me, enemyLaner, state, newState } = input;
+  if (!me) return null;
+
+  const myItemCount = me.items.filter(
+    (i) => !i.consumable && i.itemID !== 3340,
+  ).length;
+  const prevMyItems = state.lastMyItemCount;
+
+  newState.lastMyItemCount = myItemCount;
+
+  if (myItemCount > prevMyItems && prevMyItems > 0) {
+    return {
+      category: 'trading',
+      reason: 'item_completed',
+      priority: 65,
+      data: {
+        item:
+          me.items
+            .filter((i) => !i.consumable && i.itemID !== 3340)
+            .map((i) => i.displayName)
+            .pop() ?? 'an item',
+      },
+    };
+  }
+
+  if (!enemyLaner) return null;
+  const enemyItemCount = enemyLaner.items.filter(
+    (i) => !i.consumable && i.itemID !== 3340,
+  ).length;
+  const prevEnemyItems = state.lastEnemyItemCount;
+
+  newState.lastEnemyItemCount = enemyItemCount;
+
+  if (enemyItemCount > prevEnemyItems && prevEnemyItems > 0) {
+    return {
+      category: 'trading',
+      reason: 'enemy_item_completed',
+      priority: 70,
+      data: {
+        enemy: enemyLaner.championName,
+        item:
+          enemyLaner.items
+            .filter((i) => !i.consumable && i.itemID !== 3340)
+            .map((i) => i.displayName)
+            .pop() ?? 'an item',
+      },
+    };
+  }
+
+  return null;
+}
+
+export function detectKdaAdaptive(input: DetectorInput): DetectorResult | null {
+  const { me } = input;
+  if (!me) return null;
+
+  const { kills, deaths, assists } = me.scores;
+  if (deaths >= 3 && kills === 0 && assists <= 1) {
+    return {
+      category: 'mental',
+      reason: 'feeding',
+      priority: 60,
+      data: { deaths: String(deaths) },
+    };
+  }
+  if (kills >= 3 && deaths <= 1) {
+    return {
+      category: 'macro',
+      reason: 'fed',
+      priority: 55,
+      data: { kills: String(kills) },
+    };
+  }
+  return null;
+}
+
+// --- Existing detectors (ported with scoring) ---
+
+function isObjectiveUpcoming(
+  gameTime: number,
+  lastKillTime: number,
+  firstSpawnTime: number,
+  respawnDelay: number,
+): { upcoming: boolean; timeUntil: number } {
+  const nextSpawn =
+    lastKillTime === 0 ? firstSpawnTime : lastKillTime + respawnDelay;
+  const timeUntil = nextSpawn - gameTime;
+  const upcoming = timeUntil <= OBJECTIVE_UPCOMING_WINDOW_S && timeUntil > 10;
+  return { upcoming, timeUntil };
+}
+
+export function detectObjectiveUpcoming(
+  input: DetectorInput,
+): DetectorResult | null {
+  const gameTime = input.snapshot.gameData.gameTime;
+
+  const baron = isObjectiveUpcoming(
+    gameTime,
+    input.state.lastBaronKillTime,
+    BARON_FIRST_SPAWN_S,
+    BARON_RESPAWN_S,
+  );
+  if (baron.upcoming) {
+    return {
+      category: 'objectives',
+      reason: 'baron_upcoming',
+      priority: 88,
+      data: { time_until: String(Math.round(baron.timeUntil)) },
+    };
+  }
+
+  const dragon = isObjectiveUpcoming(
+    gameTime,
+    input.state.lastDragonKillTime,
+    DRAGON_FIRST_SPAWN_S,
+    DRAGON_RESPAWN_S,
+  );
+  if (dragon.upcoming) {
+    return {
+      category: 'objectives',
+      reason: 'dragon_upcoming',
+      priority: 82,
+      data: { time_until: String(Math.round(dragon.timeUntil)) },
+    };
+  }
+
+  return null;
+}
+
+export function detectCsBehind(input: DetectorInput): DetectorResult | null {
+  const { me, enemyLaner, snapshot } = input;
+  if (!me) return null;
+
+  const gameTime = snapshot.gameData.gameTime;
+  const expectedCS = (gameTime / 60) * 10;
+  if (expectedCS <= 20) return null;
+
+  if (
+    me.scores.creepScore < expectedCS * CS_THRESHOLD &&
+    (!enemyLaner || me.scores.creepScore < enemyLaner.scores.creepScore - 2)
+  ) {
+    return {
+      category: 'wave_management',
+      reason: 'cs_behind',
+      priority: 45,
+      data: {
+        my_cs: String(me.scores.creepScore),
+        expected_cs: String(Math.round(expectedCS)),
+        enemy_cs: String(enemyLaner?.scores.creepScore ?? '?'),
+      },
+    };
+  }
+  return null;
+}
+
+export function detectGold(input: DetectorInput): DetectorResult | null {
+  const gold = input.snapshot.activePlayer.currentGold;
+  if (gold >= GOLD_RECALL_MIN && gold <= GOLD_RECALL_MAX) {
+    return {
+      category: 'reset_timing',
+      reason: 'recall_window',
+      priority: 50,
+      data: { gold: String(Math.round(gold)) },
+    };
+  }
+  if (gold >= GOLD_SITTING) {
+    return {
+      category: 'reset_timing',
+      reason: 'sitting_on_gold',
+      priority: 60,
+      data: { gold: String(Math.round(gold)) },
+    };
+  }
+  return null;
+}
+
+export function detectLevelSpike(input: DetectorInput): DetectorResult | null {
+  const level = input.snapshot.activePlayer.level;
+  if (
+    level > input.state.lastKnownLevel &&
+    TRADING_LEVEL_SPIKES.includes(level)
+  ) {
+    return {
+      category: 'trading',
+      reason: `level_${level}`,
+      priority: 72,
+      data: { level: String(level) },
+    };
+  }
+  return null;
+}
+
+export function detectVision(input: DetectorInput): DetectorResult | null {
+  const gameTime = input.snapshot.gameData.gameTime;
+  if (gameTime - input.newState.lastVisionCheckAt >= VISION_CHECK_INTERVAL_S) {
+    input.newState.lastVisionCheckAt = gameTime;
+    return {
+      category: 'vision',
+      reason: 'periodic',
+      priority: 30,
+      data: {},
+    };
+  }
+  return null;
+}
+
+export function detectTabCheck(input: DetectorInput): DetectorResult | null {
+  const gameTime = input.snapshot.gameData.gameTime;
+  if (gameTime - input.newState.lastTabCheckAt >= TAB_CHECK_INTERVAL_S) {
+    input.newState.lastTabCheckAt = gameTime;
+    return {
+      category: 'tab_check',
+      reason: 'periodic',
+      priority: 25,
+      data: {},
+    };
+  }
+  return null;
+}
+
+export const ALL_DETECTORS = [
+  detectDeath,
+  detectTeamfight,
+  detectPlayerKill,
+  detectObjectiveTaken,
+  detectObjectiveUpcoming,
+  detectHpCritical,
+  detectEnemyDeathWindow,
+  detectLevelSpike,
+  detectItemCompleted,
+  detectKdaAdaptive,
+  detectCsBehind,
+  detectGold,
+  detectVision,
+  detectTabCheck,
+] as const;

--- a/src/main/detectors.ts
+++ b/src/main/detectors.ts
@@ -157,56 +157,65 @@ export function detectEnemyDeathWindow(
   };
 }
 
+function getRealItems(player: Player): Player['items'] {
+  return player.items.filter((i) => !i.consumable && i.itemID !== 3340);
+}
+
+function findNewItemName(
+  current: Player['items'],
+  prevIds: number[],
+): string | null {
+  const prevSet = new Set(prevIds);
+  const newItem = current.find((i) => !prevSet.has(i.itemID));
+  return newItem?.displayName ?? null;
+}
+
 export function detectItemCompleted(
   input: DetectorInput,
 ): DetectorResult | null {
   const { me, enemyLaner, state, newState } = input;
   if (!me) return null;
 
-  const myItemCount = me.items.filter(
-    (i) => !i.consumable && i.itemID !== 3340,
-  ).length;
-  const prevMyItems = state.lastMyItemCount;
+  const myItems = getRealItems(me);
+  const myItemIds = myItems.map((i) => i.itemID);
+  newState.lastMyItemIds = myItemIds;
 
-  newState.lastMyItemCount = myItemCount;
-
-  if (myItemCount > prevMyItems && prevMyItems > 0) {
-    return {
-      category: 'trading',
-      reason: 'item_completed',
-      priority: 65,
-      data: {
-        item:
-          me.items
-            .filter((i) => !i.consumable && i.itemID !== 3340)
-            .map((i) => i.displayName)
-            .pop() ?? 'an item',
-      },
-    };
+  if (
+    state.lastMyItemIds.length > 0 &&
+    myItemIds.length > state.lastMyItemIds.length
+  ) {
+    const itemName = findNewItemName(myItems, state.lastMyItemIds);
+    if (itemName) {
+      return {
+        category: 'trading',
+        reason: 'item_completed',
+        priority: 65,
+        data: { item: itemName },
+      };
+    }
   }
 
   if (!enemyLaner) return null;
-  const enemyItemCount = enemyLaner.items.filter(
-    (i) => !i.consumable && i.itemID !== 3340,
-  ).length;
-  const prevEnemyItems = state.lastEnemyItemCount;
+  const enemyItems = getRealItems(enemyLaner);
+  const enemyItemIds = enemyItems.map((i) => i.itemID);
+  newState.lastEnemyItemIds = enemyItemIds;
 
-  newState.lastEnemyItemCount = enemyItemCount;
-
-  if (enemyItemCount > prevEnemyItems && prevEnemyItems > 0) {
-    return {
-      category: 'trading',
-      reason: 'enemy_item_completed',
-      priority: 70,
-      data: {
-        enemy: enemyLaner.championName,
-        item:
-          enemyLaner.items
-            .filter((i) => !i.consumable && i.itemID !== 3340)
-            .map((i) => i.displayName)
-            .pop() ?? 'an item',
-      },
-    };
+  if (
+    state.lastEnemyItemIds.length > 0 &&
+    enemyItemIds.length > state.lastEnemyItemIds.length
+  ) {
+    const itemName = findNewItemName(enemyItems, state.lastEnemyItemIds);
+    if (itemName) {
+      return {
+        category: 'trading',
+        reason: 'enemy_item_completed',
+        priority: 70,
+        data: {
+          enemy: enemyLaner.championName,
+          item: itemName,
+        },
+      };
+    }
   }
 
   return null;
@@ -222,7 +231,7 @@ export function detectKdaAdaptive(input: DetectorInput): DetectorResult | null {
       category: 'mental',
       reason: 'feeding',
       priority: 60,
-      data: { deaths: String(deaths) },
+      data: { kills: String(kills), deaths: String(deaths) },
     };
   }
   if (kills >= 3 && deaths <= 1) {
@@ -230,7 +239,7 @@ export function detectKdaAdaptive(input: DetectorInput): DetectorResult | null {
       category: 'macro',
       reason: 'fed',
       priority: 55,
-      data: { kills: String(kills) },
+      data: { kills: String(kills), deaths: String(deaths) },
     };
   }
   return null;
@@ -308,7 +317,9 @@ export function detectCsBehind(input: DetectorInput): DetectorResult | null {
       data: {
         my_cs: String(me.scores.creepScore),
         expected_cs: String(Math.round(expectedCS)),
-        enemy_cs: String(enemyLaner?.scores.creepScore ?? '?'),
+        ...(enemyLaner
+          ? { enemy_cs: String(enemyLaner.scores.creepScore) }
+          : {}),
       },
     };
   }

--- a/src/main/detectors.ts
+++ b/src/main/detectors.ts
@@ -87,7 +87,9 @@ export function detectObjectiveTaken(
 }
 
 export function detectTeamfight(input: DetectorInput): DetectorResult | null {
-  const { newEvents, snapshot } = input;
+  const { newEvents, snapshot, me } = input;
+  if (!me) return null;
+
   const gameTime = snapshot.gameData.gameTime;
   const recentKills = newEvents.filter(
     (e) => e.EventName === 'ChampionKill' && gameTime - e.EventTime < 10,
@@ -98,7 +100,7 @@ export function detectTeamfight(input: DetectorInput): DetectorResult | null {
     const killer = snapshot.allPlayers.find(
       (p) => p.riotIdGameName === e.KillerName,
     );
-    return killer && killer.team === (input.me?.team ?? 'ORDER');
+    return killer && killer.team === me.team;
   }).length;
 
   const won = myTeamKills > recentKills.length - myTeamKills;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -11,6 +11,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { Position } from '../types.js';
 import {
+  cycleOutputMode,
   handleServerMessage,
   stopPromptLoop,
   togglePromptLoop,
@@ -137,6 +138,14 @@ app.whenReady().then(() => {
 
   globalShortcut.register('CommandOrControl+Shift+M', () => {
     togglePromptLoop(overlay);
+  });
+
+  globalShortcut.register('CommandOrControl+Shift+S', () => {
+    const mode = cycleOutputMode();
+    overlay.webContents.send('state-change', {
+      state: 'active',
+      prompt: `Output: ${mode}`,
+    });
   });
 
   app.on('before-quit', () => {

--- a/src/main/phases.ts
+++ b/src/main/phases.ts
@@ -1,0 +1,84 @@
+import type { PromptCategory } from '../types.js';
+
+export type GamePhase =
+  | 'early_laning'
+  | 'mid_laning'
+  | 'mid_game'
+  | 'late_game';
+
+type PhaseBoundary = {
+  phase: GamePhase;
+  minTime: number;
+};
+
+const PHASE_BOUNDARIES: readonly PhaseBoundary[] = [
+  { phase: 'late_game', minTime: 1500 },
+  { phase: 'mid_game', minTime: 840 },
+  { phase: 'mid_laning', minTime: 480 },
+  { phase: 'early_laning', minTime: 0 },
+];
+
+export function getGamePhase(gameTimeSeconds: number): GamePhase {
+  for (const { phase, minTime } of PHASE_BOUNDARIES) {
+    if (gameTimeSeconds >= minTime) return phase;
+  }
+  return 'early_laning';
+}
+
+// Multiplier per category per phase. 0 = suppressed, 1 = normal, 2 = boosted.
+const PHASE_WEIGHTS: Record<
+  GamePhase,
+  Partial<Record<PromptCategory, number>>
+> = {
+  early_laning: {
+    wave_management: 2,
+    trading: 2,
+    vision: 0.5,
+    objectives: 0.5,
+    macro: 0.5,
+    reset_timing: 1.5,
+    map_awareness: 1,
+    tab_check: 0.5,
+    mental: 1,
+  },
+  mid_laning: {
+    wave_management: 1.5,
+    trading: 1,
+    vision: 1.5,
+    objectives: 1.5,
+    macro: 1,
+    reset_timing: 1,
+    map_awareness: 1.5,
+    tab_check: 1,
+    mental: 1,
+  },
+  mid_game: {
+    wave_management: 0.5,
+    trading: 0.5,
+    vision: 1.5,
+    objectives: 2,
+    macro: 2,
+    reset_timing: 1,
+    map_awareness: 1.5,
+    tab_check: 1.5,
+    mental: 1,
+  },
+  late_game: {
+    wave_management: 0.5,
+    trading: 0.1,
+    vision: 1.5,
+    objectives: 2,
+    macro: 2,
+    reset_timing: 1.5,
+    map_awareness: 1,
+    tab_check: 1,
+    mental: 1.5,
+  },
+};
+
+export function getCategoryWeight(
+  phase: GamePhase,
+  category: PromptCategory,
+): number {
+  return PHASE_WEIGHTS[phase][category] ?? 1;
+}

--- a/src/main/prompts.ts
+++ b/src/main/prompts.ts
@@ -12,20 +12,73 @@ import {
   initialContextState,
   type ContextState,
 } from './context.js';
+import { canResolve, resolveTemplate } from './templates.js';
+
+const PROMPT_HISTORY_MAX = 20;
+const PROMPT_REPEAT_WINDOW_MS = 300_000; // 5 minutes
+
+type PromptHistoryEntry = {
+  text: string;
+  category: PromptCategory;
+  time: number;
+};
 
 let contextState: ContextState = { ...initialContextState };
-let lastCategory: PromptCategory | null = null;
 let cooldownTimer: NodeJS.Timeout;
 let inCooldown = false;
 let paused = false;
+let promptHistory: PromptHistoryEntry[] = [];
 
 type EngineStatus = 'WAITING_FOR_GAME' | 'ACTIVE';
 let engineStatus: EngineStatus = 'WAITING_FOR_GAME';
 
+export type OutputMode = 'overlay' | 'speech' | 'both';
 export type EngineTransition = 'game-started' | 'game-ended' | null;
 
+const VALID_OUTPUT_MODES = new Set<OutputMode>(['overlay', 'speech', 'both']);
+const configMode = (config as { output_mode?: string }).output_mode;
+let outputMode: OutputMode = VALID_OUTPUT_MODES.has(configMode as OutputMode)
+  ? (configMode as OutputMode)
+  : 'both';
+
+export function getOutputMode(): OutputMode {
+  return outputMode;
+}
+
+export function cycleOutputMode(): OutputMode {
+  const modes: OutputMode[] = ['overlay', 'speech', 'both'];
+  const idx = modes.indexOf(outputMode);
+  outputMode = modes[(idx + 1) % modes.length]!;
+  return outputMode;
+}
+
 function sendStateChange(win: BrowserWindow, event: StateChangeEvent) {
-  win.webContents.send('state-change', event);
+  const mode = outputMode;
+  if (mode === 'overlay' || mode === 'both') {
+    win.webContents.send('state-change', event);
+  }
+  if ((mode === 'speech' || mode === 'both') && event.state === 'active') {
+    win.webContents.send('speak-prompt', event.prompt);
+  }
+}
+
+function wasRecentlyShown(text: string): boolean {
+  const now = Date.now();
+  return promptHistory.some(
+    (entry) =>
+      entry.text === text && now - entry.time < PROMPT_REPEAT_WINDOW_MS,
+  );
+}
+
+function wasCategoryRecentlyUsed(category: PromptCategory): boolean {
+  return promptHistory.length > 0 && promptHistory[0]?.category === category;
+}
+
+function recordPrompt(text: string, category: PromptCategory) {
+  promptHistory.unshift({ text, category, time: Date.now() });
+  if (promptHistory.length > PROMPT_HISTORY_MAX) {
+    promptHistory = promptHistory.slice(0, PROMPT_HISTORY_MAX);
+  }
 }
 
 function pickPrompt(snapshot: GameSnapshot): string | null {
@@ -33,13 +86,21 @@ function pickPrompt(snapshot: GameSnapshot): string | null {
   contextState = newState;
 
   if (!result) return null;
-  if (result.category === lastCategory) return null;
+  if (wasCategoryRecentlyUsed(result.category)) return null;
 
   const pool = prompts[result.category];
   if (!pool || pool.length === 0) return null;
 
-  lastCategory = result.category;
-  return pool[Math.floor(Math.random() * pool.length)] ?? null;
+  const resolved = pool
+    .filter((template) => canResolve(template, result.data))
+    .map((template) => resolveTemplate(template, result.data))
+    .filter((text) => !wasRecentlyShown(text));
+
+  if (resolved.length === 0) return null;
+
+  const picked = resolved[Math.floor(Math.random() * resolved.length)]!;
+  recordPrompt(picked, result.category);
+  return picked;
 }
 
 function evaluate(snapshot: GameSnapshot, win: BrowserWindow) {
@@ -86,7 +147,7 @@ function resetState() {
   paused = false;
   engineStatus = 'WAITING_FOR_GAME';
   contextState = { ...initialContextState };
-  lastCategory = null;
+  promptHistory = [];
 }
 
 export function stopPromptLoop() {

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -3,7 +3,23 @@ import https from 'node:https';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import type { GameSnapshot } from '../riot.types.js';
 import type { ServerMessage } from '../types.js';
+
+function isValidSnapshot(data: unknown): data is GameSnapshot {
+  if (typeof data !== 'object' || data === null) return false;
+  const d = data as Record<string, unknown>;
+  return (
+    typeof d.activePlayer === 'object' &&
+    d.activePlayer !== null &&
+    Array.isArray(d.allPlayers) &&
+    typeof d.events === 'object' &&
+    d.events !== null &&
+    typeof d.gameData === 'object' &&
+    d.gameData !== null &&
+    typeof (d.gameData as Record<string, unknown>).gameTime === 'number'
+  );
+}
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, '..', '..');
@@ -46,6 +62,9 @@ async function getLiveGameData(): Promise<ServerMessage> {
       'https://127.0.0.1:2999/liveclientdata/allgamedata',
       { httpsAgent, timeout: 1000 },
     );
+    if (!isValidSnapshot(data)) {
+      return { type: 'FETCH_ERROR', reason: 'Invalid or partial game data' };
+    }
     return { type: 'DATA', payload: data };
   } catch (error: unknown) {
     return {

--- a/src/main/templates.ts
+++ b/src/main/templates.ts
@@ -1,0 +1,26 @@
+/**
+ * Resolves template strings by replacing {placeholders} with data values.
+ * Unknown placeholders are left as-is to avoid broken output.
+ *
+ * Example: resolve("Enemy {enemy} has {item}", { enemy: "Zed", item: "Duskblade" })
+ *       -> "Enemy Zed has Duskblade"
+ */
+export function canResolve(
+  template: string,
+  data: Record<string, string>,
+): boolean {
+  const placeholders = template.matchAll(/\{(\w+)\}/g);
+  for (const [, key] of placeholders) {
+    if (!(key! in data)) return false;
+  }
+  return true;
+}
+
+export function resolveTemplate(
+  template: string,
+  data: Record<string, string>,
+): string {
+  return template.replaceAll(/\{(\w+)\}/g, (match, key: string) => {
+    return data[key] ?? match;
+  });
+}

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -16,6 +16,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('app-status', (_event: IpcRendererEvent, value: AppStatus) =>
       callback(value),
     ),
+  onSpeakPrompt: (callback: (text: string) => void) =>
+    ipcRenderer.on('speak-prompt', (_event: IpcRendererEvent, value: string) =>
+      callback(value),
+    ),
   setPosition: (position: { dx: number; dy: number }) => {
     ipcRenderer.send('set-position', position);
   },

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -16,6 +16,15 @@ window.addEventListener('DOMContentLoaded', () => {
     }
   });
 
+  window.electronAPI.onSpeakPrompt((text) => {
+    speechSynthesis.cancel();
+    const utterance = new SpeechSynthesisUtterance(text);
+    utterance.rate = 1.1;
+    utterance.pitch = 1;
+    utterance.volume = 0.8;
+    speechSynthesis.speak(utterance);
+  });
+
   const beacon = document.getElementById('beacon');
 
   let dragging = false;

--- a/src/riot.types.ts
+++ b/src/riot.types.ts
@@ -1,31 +1,147 @@
+export type Ability = {
+  abilityLevel: number;
+  displayName: string;
+  id: string;
+  rawDescription: string;
+  rawDisplayName: string;
+};
+
+export type Abilities = {
+  Passive: Omit<Ability, 'abilityLevel'>;
+  Q: Ability;
+  W: Ability;
+  E: Ability;
+  R: Ability;
+};
+
+export type ChampionStats = {
+  abilityHaste: number;
+  abilityPower: number;
+  armor: number;
+  armorPenetrationFlat: number;
+  armorPenetrationPercent: number;
+  attackDamage: number;
+  attackRange: number;
+  attackSpeed: number;
+  bonusArmorPenetrationPercent: number;
+  bonusMagicPenetrationPercent: number;
+  critChance: number;
+  critDamage: number;
+  currentHealth: number;
+  healShieldPower: number;
+  healthRegenRate: number;
+  lifeSteal: number;
+  magicLethality: number;
+  magicPenetrationFlat: number;
+  magicPenetrationPercent: number;
+  magicResist: number;
+  maxHealth: number;
+  moveSpeed: number;
+  omnivamp: number;
+  physicalLethality: number;
+  physicalVamp: number;
+  resourceMax: number;
+  resourceRegenRate: number;
+  resourceType: string;
+  resourceValue: number;
+  spellVamp: number;
+  tenacity: number;
+};
+
+export type Rune = {
+  displayName: string;
+  id: number;
+  rawDescription: string;
+  rawDisplayName: string;
+};
+
+export type FullRunes = {
+  generalRunes: Rune[];
+  keystone: Rune;
+  primaryRuneTree: Rune;
+  secondaryRuneTree: Rune;
+  statRunes: { id: number; rawDescription: string }[];
+};
+
 export type ActivePlayer = {
+  abilities: Abilities;
+  championStats: ChampionStats;
   currentGold: number;
+  fullRunes: FullRunes;
   level: number;
   riotId: string;
   riotIdGameName: string;
+  riotIdTagLine: string;
+  summonerName: string;
+};
+
+export type Item = {
+  canUse: boolean;
+  consumable: boolean;
+  count: number;
+  displayName: string;
+  itemID: number;
+  price: number;
+  rawDescription: string;
+  rawDisplayName: string;
+  slot: number;
+};
+
+export type SummonerSpell = {
+  displayName: string;
+  rawDescription: string;
+  rawDisplayName: string;
+};
+
+export type PlayerRunes = {
+  keystone: Rune;
+  primaryRuneTree: Rune;
+  secondaryRuneTree: Rune;
 };
 
 export type PlayerScores = {
+  assists: number;
   creepScore: number;
+  deaths: number;
+  kills: number;
+  wardScore: number;
 };
 
 export type Player = {
-  riotId: string;
-  position: 'TOP' | 'JUNGLE' | 'MIDDLE' | 'BOTTOM' | 'UTILITY';
-  team: 'ORDER' | 'CHAOS';
+  championName: string;
+  isBot: boolean;
   isDead: boolean;
+  items: Item[];
+  level: number;
+  position: 'TOP' | 'JUNGLE' | 'MIDDLE' | 'BOTTOM' | 'UTILITY';
+  respawnTimer: number;
+  riotId: string;
+  riotIdGameName: string;
+  riotIdTagLine: string;
+  runes: PlayerRunes;
   scores: PlayerScores;
+  summonerSpells: {
+    summonerSpellOne: SummonerSpell;
+    summonerSpellTwo: SummonerSpell;
+  };
+  team: 'ORDER' | 'CHAOS';
 };
 
 export type GameEvent = {
   EventID: number;
   EventName: string;
   EventTime: number;
+  Assisters?: string[];
   KillerName?: string;
+  VictimName?: string;
 };
 
 export type GameData = {
+  gameMode: string;
   gameTime: number;
+  mapName: string;
+  mapNumber: number;
+  mapTerrain: string;
 };
 
 export type GameSnapshot = {


### PR DESCRIPTION
**What changed**

Replaced the flat prompt engine with a scored detector system. 14 detectors run every tick, scored by priority and multiplied by game phase weights. Prompts now use `{placeholder}` templates that inject live game data (champion names, gold, CS, timers). Added speech synthesis as an alternative output mode.

**Why**

The old engine picked random prompts from category pools with a fixed priority chain. It ignored most of the data from the Riot Live Client API (items, KDA, champion stats, abilities, respawn timers). The new system is context-aware and adapts to game phase.

**How to test**
- [ ] Run `npx vitest run` -- 56 tests pass
- [ ] Start a game and verify prompts show resolved data (gold, CS, champion names)
- [ ] Test Ctrl+Shift+S cycles through overlay -> speech -> both
- [ ] Verify no literal `{placeholder}` text appears in overlay during gameplay
- [ ] Test speech output works on Windows
- [ ] Verify late-game phase suppresses trading/wave prompts

**Checklist**
- [x] Builds clean
- [x] Tests pass
- [ ] Tested manually